### PR TITLE
Update for modern ruby.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ pkg/
 *.bundle
 Gemfile.lock
 tmp/
+/Makefile
+/mkmf.log
+mmap-*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'rake', '~> 10.4.2'
+gem 'rake-compiler', '~> 0.9.5'

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -6,6 +6,7 @@ b.rb
 ext/mmap/extconf.rb
 ext/mmap/mmap.c
 lib/mmap.rb
+lib/mmap/version.rb
 mmap.html
 mmap.rd
 test/test_mmap.rb

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ require "rake/extensiontask"
 
 HOE = Hoe.spec 'mmap' do
   developer('Guy Decoux', 'ts@moulon.inra.fr')
+  license('Ruby')
   self.readme_file   = 'README.rdoc'
   self.history_file  = 'Changes'
   self.extra_rdoc_files  = FileList['*.rdoc']
@@ -16,10 +17,10 @@ HOE = Hoe.spec 'mmap' do
     self.extra_dev_deps << [dep, '>= 0']
   end
 
-  self.spec_extras = { :extensions => ["ext/mmap/extconf.rb"] }
+  spec_extras[:extensions] = ['ext/mmap/extconf.rb']
 end
 
-RET = Rake::ExtensionTask.new("mmap", HOE.spec) do |ext|
+RET = Rake::ExtensionTask.new('mmap', HOE.spec) do |ext|
   ext.lib_dir = File.join('lib', 'mmap')
 end
 

--- a/ext/mmap/extconf.rb
+++ b/ext/mmap/extconf.rb
@@ -19,4 +19,4 @@ if enable_config("ipc")
    end
 end
 
-create_makefile "mmap"
+create_makefile "mmap/mmap"

--- a/lib/mmap.rb
+++ b/lib/mmap.rb
@@ -4,13 +4,12 @@
 #
 # === WARNING
 # === The variables $' and $` are not available with gsub! and sub!
-require 'mmap/mmap'
+require 'mmap/mmap' unless defined? Mmap
+require 'mmap/version'
 
 class Mmap
   include Comparable
   include Enumerable
-
-  VERSION = '0.2.6'
 
   def clone # :nodoc:
     raise TypeError, "can't clone instance of #{self.class}"

--- a/lib/mmap/version.rb
+++ b/lib/mmap/version.rb
@@ -1,0 +1,5 @@
+# Version of mmap.
+
+class Mmap
+  VERSION = '0.2.8'
+end

--- a/mmap.gemspec
+++ b/mmap.gemspec
@@ -1,24 +1,17 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'mmap'
+require File.expand_path('../lib/mmap/version', __FILE__)
 
-Gem::Specification.new do |spec|
+Mmap::GEMSPEC = Gem::Specification.new do |spec|
   spec.name          = "mmap"
   spec.version       = Mmap::VERSION
   spec.authors       = ["Guy Decoux", "Aaron Patterson"]
+  spec.license       = "Ruby"
   spec.email         = ["ts@moulon.inra.fr", "tenderlove@github.com"]
-  spec.description   = %q{The Mmap class implement memory-mapped file objects}
-  spec.summary       = %q{The Mmap class implement memory-mapped file objects}
+  spec.extensions    = ["ext/mmap/extconf.rb"]
   spec.homepage      = "https://github.com/tenderlove/mmap"
-  spec.license       = "https://www.ruby-lang.org/en/about/license.txt"
+  spec.description   = %q{The Mmap class implement memory-mapped file objects}
+  spec.summary       = %q{The Mmap class}
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
-
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rake-compiler"
-  spec.add_development_dependency "hoe"
+  spec.files         = `git ls-files Changes README.rdoc ext lib mmap.rd`.split
+  spec.test_files    = `git ls-files b.rb test`.split
 end


### PR DESCRIPTION
Move version into mmap/version.rb.
Update gemspec with modern settings.
Update gitignore.
Can now be installed with ruby 2.x.

This should resolve issue #6 and #1. There are some other pull requests that also fix this, but this generally stays with the way you've built it in the past.

Regardless, could one of them get merged and then released as the current mmap gem doesn't work with modern rubies.