### PR TITLE
Add support for updating and inserting bare numbers

### DIFF
--- a/ext/mmap/mmap.c
+++ b/ext/mmap/mmap.c
@@ -1074,7 +1074,11 @@ mm_update(str, beg, len, val)
     }
 
     mm_unlock(str);
-    StringMmap(val, valp, vall);
+    if (FIXNUM_P(val)) {
+        vall = 1;
+    } else {
+      StringMmap (val, valp, vall);
+    }
     mm_lock(str, Qtrue);
 
     if ((str->t->flag & MM_FIXED) && vall != len) {
@@ -1093,8 +1097,12 @@ mm_update(str, beg, len, val)
     if (str->t->real < (size_t)beg && len < 0) {
 	MEMZERO(str->t->addr + str->t->real, char, -len);
     }
-    if (vall > 0) {
-	memmove((char *)str->t->addr + beg, valp, vall);
+    if (vall > 0 && FIXNUM_P(val)){
+        int offset = beg;
+        char *ptr = (char *)str->t->addr + offset;
+        *ptr = FIX2INT(val);
+    } else if (vall > 0) {
+	    memmove((char *)str->t->addr + beg, valp, vall);
     }
     str->t->real += vall - len;
     mm_unlock(str);

--- a/test/test_mmap.rb
+++ b/test/test_mmap.rb
@@ -370,4 +370,19 @@ class TestMmap < Minitest::Test
       end
     end
   end
+
+  def test_insert_integer
+    m = @mmap
+    s = m.size
+    m.insert(0, 1)
+    assert_equal(s+1, m.size)
+    assert_equal(1, m[0].ord)
+
+    m[0,4] = "\x01\x01\x01\x01"
+    assert_equal("\x01", m[0])
+    m[0] = 0
+    assert_equal("\x00",m[0])
+    m[0] = 1
+    assert_equal("\x01",m[0])
+  end
 end


### PR DESCRIPTION
I needed to share integers between two processes and wanted to use mmap. While it supports #insert of strings, it did not support the same for numbers. I'm note sure I sized things right, but the tests pass.